### PR TITLE
Add a TODO about hardcoded age of commits in `FakeGitHub`

### DIFF
--- a/features/step_definitions/steps.ts
+++ b/features/step_definitions/steps.ts
@@ -35,6 +35,9 @@ class FakeGitHub implements Github {
   }
 
   getAgeOfLastCommitBy(user: string): number {
+    console.log(
+      "TODO: don't hard-code age of commit; look it up from a list of (fake) commits"
+    )
     return 365
   }
 }


### PR DESCRIPTION
### 🤔 What's changed?

* Added a TODO to remind us not to hard-code the result of `FakeGitHub#getAgeOfLastCommitBy` to `365`

### ⚡️ What's your motivation? 

* To help us not forget all the things we need to do for our work on in this next iteration to be complete

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without changing behaviour)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
