### PR TITLE
Rationalise test runner scripts

### DIFF
--- a/features/move_inactive_users.feature
+++ b/features/move_inactive_users.feature
@@ -23,6 +23,7 @@ Feature: Move inactive users
 
   Rule: Move inactive users into alumni team from any other team
 
+    @todo
     Scenario: Julien is a member of the cucumber-js-admin tea
       Given a user Julien is a member of the cucumber-js-admin team
       And the create date of Julien's last commit was 365 days ago
@@ -32,6 +33,7 @@ Feature: Move inactive users
 
   Rule: Remove any custom repo permissions from inactive users
 
+    @todo
     Scenario: Matt has custom permissions
       Given a user Matt has write access to the cucumber-js repo
       And the create date of Matt's last commit was 365 days ago
@@ -43,6 +45,7 @@ Feature: Move inactive users
 		This helps us to know whether we have the right time-frame for retiring people - if there are lots of people
 		in both committers and alumni, it means we're maybe retiring people too soon.
 
+    @todo
     Scenario: Demi who was formerly inactive, recently became active again
       Given a user Demi is part of the alumni team
       And the create date of Demi's last commit was 1 day ago

--- a/package.json
+++ b/package.json
@@ -11,8 +11,9 @@
   ],
   "scripts": {
     "build": "tsc",
-    "test": "npm run test:unit && cucumber-js",
-    "test:wip": "cucumber-js --tags @wip",
+    "test": "npm run test:unit && npm run test:acceptance",
+    "test:acceptance": "cucumber-js --tags 'not @todo and not @wip'",
+    "test:acceptance:wip": "cucumber-js --tags @wip",
     "test:unit": "mocha src/**/*.test.ts"
   },
   "devDependencies": {


### PR DESCRIPTION
### 🤔 What's changed?

* Tagged all non-complete scenarios with `@todo`
* Added a `test:acceptance` script which runs all the scenarios that should be expected to pass (i.e. those not tagged with `@wip` or `@todo`)
* Changed the name of `test:wip` to `test:acceptance:wip` since it's only running acceptance tests
* Changed the main `npm test` script to use the `test:acceptance` script.

### ⚡️ What's your motivation? 

Now that we've added unit tests into the mix, and that we have some scenarios in a "done" state, I want to make sure we have an `npm test` that we can expect to pass.

It's a pre-cursor for doing #4 

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without changing behaviour)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
