### PR TITLE
Restore npm old npm scripts from before eslint was added

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,10 @@
   ],
   "scripts": {
     "build": "tsc",
-    "start": "probot run ./lib/index.js",
-    "test": "cucumber-js",
-    "test:wip": "cucumber-js --tags @wip",
+    "test": "npm run test:unit && npm run test:acceptance",
+    "test:acceptance": "cucumber-js --tags 'not @todo and not @wip'",
+    "test:acceptance:wip": "cucumber-js --tags @wip",
+    "test:unit": "mocha src/**/*.test.ts",
     "lint": "eslint . --ext .ts",
     "format": "prettier --config .prettierrc 'src/**/*.ts' --write"
   },


### PR DESCRIPTION
### 🤔 What's changed?

* Restored a few lines from the `package.json` that were lost in commit 4c850033fd5333315d46dddbb5aa7b1fbcc714ac

### ⚡️ What's your motivation? 

Restore the newer test runner script added in https://github.com/cucumber/action-retire-inactive-contributor/commit/2b8727e1ce5b89e485ac17d8953f21cc12977697

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?

I'm assuming this "regression" was not intentional. Please let me know if it was!

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
