### PR TITLE
Format code in `features` too

### DIFF
--- a/features/step_definitions/steps.ts
+++ b/features/step_definitions/steps.ts
@@ -4,10 +4,10 @@ import {
   When,
   Then,
   defineParameterType,
-} from "@cucumber/cucumber"
-import assert from "assert"
-import { Commit, Github } from "../../src/retireInactiveContributors"
-import { retireInactiveContributors } from "../../src/retireInactiveContributors"
+} from '@cucumber/cucumber'
+import assert from 'assert'
+import { Commit, Github } from '../../src/retireInactiveContributors'
+import { retireInactiveContributors } from '../../src/retireInactiveContributors'
 
 type World = { github: FakeGitHub }
 
@@ -55,26 +55,26 @@ Before(function () {
 defineParameterType({
   regexp: /the ([\w-]+) team/,
   transformer: (teamName: string) => teamName,
-  name: "team",
+  name: 'team',
 })
 
 defineParameterType({
   regexp: /([A-Z]\w+)/,
   transformer: (userName: string) => userName,
-  name: "user",
+  name: 'user',
 })
 
 Given(
-  "a user {user} has write access to the cucumber-js repo",
+  'a user {user} has write access to the cucumber-js repo',
   function (user: string) {
     // Write code here that turns the phrase above into concrete actions
     console.log(user)
-    return "pending"
+    return 'pending'
   }
 )
 
 Given(
-  "a user {user} is part/member of {team}",
+  'a user {user} is part/member of {team}',
   function (this: World, user: string, team: string) {
     this.github.addUserToTeam(user, team)
   }
@@ -88,22 +88,22 @@ Given(
 )
 
 Given(
-  "a user {user} is a member of {team}",
+  'a user {user} is a member of {team}',
   function (user: string, team: string) {
     // Write code here that turns the phrase above into concrete actions
     console.log(user)
     console.log(team)
-    return "pending"
+    return 'pending'
   }
 )
 
-When("the action runs", function (this: World) {
+When('the action runs', function (this: World) {
   // Write code here that turns the phrase above into concrete actions
   retireInactiveContributors(this.github)
 })
 
 Then(
-  "{user} should be in {team}",
+  '{user} should be in {team}',
   function (this: World, user: string, team: string) {
     const users = this.github.getMembersOf(team)
     assert(
@@ -114,16 +114,16 @@ Then(
 )
 
 Then(
-  "{user} should not have any custom permissions on the cucumber-js repo",
+  '{user} should not have any custom permissions on the cucumber-js repo',
   function (user: string) {
     // Write code here that turns the phrase above into concrete actions
     console.log(user)
-    return "pending"
+    return 'pending'
   }
 )
 
 Then(
-  "{user} should not be in {team}( anymore)",
+  '{user} should not be in {team}( anymore)',
   function (this: World, user: string, team: string) {
     const users = this.github.getMembersOf(team)
     assert(

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "cucumber-js",
     "test:wip": "cucumber-js --tags @wip",
     "lint": "eslint . --ext .ts",
-    "format": "prettier --config .prettierrc 'src/**/*.ts' --write"
+    "format": "prettier --config .prettierrc '{src,features}/**/*.ts' --write"
   },
   "devDependencies": {
     "@cucumber/cucumber": "^7.3.2",


### PR DESCRIPTION
### 🤔 What's changed?

* modified `npm run format` script to run on `features` directory too
* let prettier fix those files to follow the eslint rules

### ⚡️ What's your motivation? 

I want the `npm run lint` script to pass.

Ref #4 #8

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without changing behaviour)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
