### PR TITLE
Publish Cucumber Report when CI runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,3 +26,4 @@ jobs:
     - run: npm ci
     - run: npm run build --if-present
     - run: npm test
+      env: CUCUMBER_PUBLISH_TOKEN: ${{ secrets.CUCUMBER_PUBLISH_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Cucumber Report](https://messages.cucumber.io/api/report-collections/e37b01e9-023e-43aa-b510-a79705ee932f/badge)](https://reports.cucumber.io/report-collections/e37b01e9-023e-43aa-b510-a79705ee932f)
+
 # retire-inactive-contributor README.md
 
 ## Now as a Github action

--- a/cucumber.js
+++ b/cucumber.js
@@ -2,6 +2,6 @@ module.exports = {
     default: [
       "--require-module ts-node/register",
       "--require features/**/*.ts",
-      "--publish-quiet",
+      "--publish"
     ].join(" "),
   };

--- a/cucumber.js
+++ b/cucumber.js
@@ -1,7 +1,8 @@
 module.exports = {
-    default: [
-      "--require-module ts-node/register",
-      "--require features/**/*.ts",
-      "--publish"
-    ].join(" "),
+  default: [
+      '--require-module ts-node/register', 
+      '--require features/**/*.ts'
+    ]
+    .concat(process.env.CUCUMBER_PUBLISH_TOKEN ? "--publish" : "--publish-quiet")
+    .join(" "),
   };


### PR DESCRIPTION
This sets us up to publish a report to https://reports.cucumber.io/report-collections/e37b01e9-023e-43aa-b510-a79705ee932f when the tests run in CI.

I also added a README badge so you can easily access the reports.

Fixes #20 I hope? WDYT @blaisep?