### PR TITLE
Use hamjest for assertions in cukes

### DIFF
--- a/features/step_definitions/steps.ts
+++ b/features/step_definitions/steps.ts
@@ -5,9 +5,9 @@ import {
   Then,
   defineParameterType,
 } from '@cucumber/cucumber'
-import assert from 'assert'
 import { retireInactiveContributors } from '../../src/retireInactiveContributors'
 import { FakeGitHub } from '../../src/FakeGitHub'
+import { assertThat, hasItem, not } from 'hamjest'
 
 type World = { github: FakeGitHub }
 
@@ -69,10 +69,7 @@ Then(
   '{user} should be in {team}',
   async function (this: World, user: string, team: string) {
     const users = await this.github.getMembersOf(team)
-    assert(
-      users.includes(user),
-      `Could not find user: ${user} in team: ${team}. Users found: ${users}`
-    )
+    assertThat(users, hasItem(user))
   }
 )
 
@@ -89,9 +86,6 @@ Then(
   '{user} should not be in {team}( anymore)',
   async function (this: World, user: string, team: string) {
     const users = await this.github.getMembersOf(team)
-    assert(
-      !users.includes(user),
-      `Could not find user: ${user} in team: ${team}.`
-    )
+    assertThat(users, not(hasItem(user)))
   }
 )

--- a/src/FakeGitHub.test.ts
+++ b/src/FakeGitHub.test.ts
@@ -1,5 +1,5 @@
 import { FakeGitHub } from './FakeGitHub'
-import { assertThat, equalTo, falsey, is } from 'hamjest'
+import { assertThat, falsey, is } from 'hamjest'
 
 describe(FakeGitHub.name, () => {
   context('working out if a user has committed recently', () => {


### PR DESCRIPTION
### 🤔 What's changed?

Change from bog-standard `assert` calls to using hamjest in our cucumber steps

### ⚡️ What's your motivation? 

Consistency with the unit tests, also not having to hand-roll our assertions, and so making them easier to read.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without changing behaviour)

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
