### PR TITLE
Use hamjest matcher for rejected promise

### DIFF
--- a/src/OctokitGitHub.test.ts
+++ b/src/OctokitGitHub.test.ts
@@ -86,9 +86,8 @@ describe(OctokitGitHub.name, () => {
     const org = 'non-existent-org'
     const octokit = getOctokit(token())
     const gitHubClient = new OctokitGitHub(octokit, org)
-    const gettingMembers = gitHubClient.getMembersOf('fishcakes')
     await promiseThat(
-      gettingMembers,
+      gitHubClient.getMembersOf('fishcakes'),
       rejected(instanceOf(UnableToGetMembersError))
     )
   })

--- a/src/OctokitGitHub.test.ts
+++ b/src/OctokitGitHub.test.ts
@@ -9,10 +9,9 @@ import {
   is,
   not,
   promiseThat,
-  throws,
+  rejected,
 } from 'hamjest'
 import { UnableToGetMembersError } from './Errors'
-import assert from 'assert'
 
 // This really exists on GitHub
 const org = 'test-inactive-contributor-action'
@@ -88,7 +87,10 @@ describe(OctokitGitHub.name, () => {
     const octokit = getOctokit(token())
     const gitHubClient = new OctokitGitHub(octokit, org)
     const gettingMembers = gitHubClient.getMembersOf('fishcakes')
-    await assert.rejects(gettingMembers, UnableToGetMembersError)
+    await promiseThat(
+      gettingMembers,
+      rejected(instanceOf(UnableToGetMembersError))
+    )
   })
 })
 


### PR DESCRIPTION
<!---
Thanks for helping to make Cucumber better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through
to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most 
likely to make sense to other people when they are reviewing it. Still, it's just a guide, 
so feel free to delete anything that doesn't feel appropriate, and add anything additional 
that seems like it would provide useful context. 👏🏻
-->

### 🤔 What's changed?

Switch from using `assert.rejects` to hamjest matcher to stick with our default assertion style.

### ⚡️ What's your motivation? 

Keep our use of hamjest consistent. I also wanted to figure out how to do this!

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without 
### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
